### PR TITLE
Reduce required OpenGL version to 3.3

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -10,9 +10,10 @@
             .hash = "wayland-0.4.0-dev-lQa1kjfMAQAkvyX7B4XFmdZt8w6d_OCMsee6uBJZEaFu",
         },
         .zgl = .{
-            // TODO: Update to the upstream URL once this change (or similar) is merged
-            .url = "https://github.com/sin-ack/zgl/archive/b3dc4c6034bdbd574a6b448626750909e51a6c33.tar.gz",
-            .hash = "zgl-1.1.0-p_NpAKE-CgBnmyP12H-ldbZLdImx1btyk8zPx0I5CGHX",
+            // NOTE: This is my opengl-3.3 branch which lowers the required OpenGL version to 3.3
+            //       from 4.5. It is otherwise identical to zgl upstream.
+            .url = "https://github.com/sin-ack/zgl/archive/21d06c1e6187401372f174cea602eaf85ce6f804.tar.gz",
+            .hash = "zgl-1.1.0-p_NpADNjBQAEJoOxiCci_ddmXZuPx1XAkmCsTQ1_vnib",
         },
         .@"zig-args" = .{
             .url = "https://github.com/ikskuh/zig-args/archive/4c305bcb45fd3c4b74b7bf7f907cf3fc12f415a2.tar.gz",

--- a/build.zig.zon2json-lock
+++ b/build.zig.zon2json-lock
@@ -4,10 +4,10 @@
     "url": "https://codeberg.org/sin-ack/zig-wayland/archive/f18fef69b5f9096a667e7cb47fb96477657cdf92.tar.gz",
     "hash": "sha256-+8Wz1rjeL1dGx9U7heTp3fYdXUsC9NK2+SPYhRsvCDE="
   },
-  "zgl-1.1.0-p_NpAKE-CgBnmyP12H-ldbZLdImx1btyk8zPx0I5CGHX": {
+  "zgl-1.1.0-p_NpADNjBQAEJoOxiCci_ddmXZuPx1XAkmCsTQ1_vnib": {
     "name": "zgl",
-    "url": "https://github.com/sin-ack/zgl/archive/b3dc4c6034bdbd574a6b448626750909e51a6c33.tar.gz",
-    "hash": "sha256-q1LBXp2MpCzkpmCio9sgUAkpELMjE0YSade4hfAnk7I="
+    "url": "https://github.com/sin-ack/zgl/archive/21d06c1e6187401372f174cea602eaf85ce6f804.tar.gz",
+    "hash": "sha256-y0r4K20cXMBS7TxwIDCdWa8reGAEo01MzJFFx44var4="
   },
   "args-0.0.0-CiLiquDRAADuU_ueSmGquhHAuhDxxlfBokGj01ZdVYHt": {
     "name": "zig-args",

--- a/src/main.zig
+++ b/src/main.zig
@@ -490,7 +490,7 @@ const WlrSurface = struct {
 
         self.egl_context = egl_context: {
             const config_attributes = [_:egl.EGL_NONE]egl.EGLint{
-                egl.EGL_CONTEXT_MAJOR_VERSION, 4,
+                egl.EGL_CONTEXT_MAJOR_VERSION, 3,
                 egl.EGL_CONTEXT_MINOR_VERSION, 3,
             };
 
@@ -575,7 +575,7 @@ const FractionalScale = struct {
 };
 
 const vs_source =
-    \\#version 430 core
+    \\#version 330 core
     \\
     \\layout(location = 0) in vec2 position;
     \\
@@ -763,7 +763,7 @@ pub fn main() !u8 {
         .frame_rate = @floatFromInt(target_frame_rate),
     };
 
-    const vao = gl.VertexArray.create();
+    const vao = gl.VertexArray.gen();
     defer vao.delete();
     vao.bind();
 
@@ -776,29 +776,29 @@ pub fn main() !u8 {
     };
     // zig fmt: on
 
-    const vbo = gl.Buffer.create();
+    const vbo = gl.Buffer.gen();
     defer vbo.delete();
     {
         vbo.bind(.array_buffer);
-        vbo.data(f32, vertices[0..], .static_draw);
+        gl.bufferData(.array_buffer, f32, vertices[0..], .static_draw);
 
-        vao.attribFormat(0, 2, .float, false, 0);
-        vao.attribBinding(0, 0);
-        gl.bindVertexBuffer(0, vbo, 0, 2 * @sizeOf(f32));
-        vao.enableVertexAttribute(0);
+        gl.vertexAttribPointer(0, 2, .float, false, 2 * @sizeOf(f32), 0);
+        // gl.vertexAttribBinding(0, 0);
+        // gl.bindVertexBuffer(0, vbo, 0, 2 * @sizeOf(f32));
+        gl.enableVertexAttribArray(0);
     }
 
-    const ubo = gl.Buffer.create();
+    const ubo = gl.Buffer.gen();
     defer ubo.delete();
     ubo.bind(.uniform_buffer);
-    ubo.data(Uniforms, &.{uniforms}, .static_draw);
+    gl.bufferData(.uniform_buffer, Uniforms, &.{uniforms}, .static_draw);
     gl.bindBufferBase(.uniform_buffer, 0, ubo);
 
-    const ebo = gl.Buffer.create();
+    const ebo = gl.Buffer.gen();
     defer ebo.delete();
     {
         ebo.bind(.element_array_buffer);
-        ebo.data(u8, &.{
+        gl.bufferData(.element_array_buffer, u8, &.{
             0, 1, 2, // Top-left triangle
             2, 3, 0, // Bottom-right triangle
         }, .static_draw);
@@ -858,7 +858,7 @@ pub fn main() !u8 {
 
         program.use();
         vao.bind();
-        ubo.data(Uniforms, &.{uniforms}, .static_draw);
+        gl.bufferData(.uniform_buffer, Uniforms, &.{uniforms}, .static_draw);
 
         gl.drawElements(.triangles, 6, .unsigned_byte, 0);
 

--- a/src/shadertoy_preamble.glsl
+++ b/src/shadertoy_preamble.glsl
@@ -1,8 +1,8 @@
 // Adapted from https://github.com/ghostty-org/ghostty/blob/main/src/renderer/shaders/shadertoy_prefix.glsl
 // Copyright (c) 2024 Mitchell Hashimoto, License: MIT
-#version 430 core
+#version 330 core
 
-layout(binding = 0) uniform Globals {
+/* layout(binding = 0) */ uniform Globals {
     uniform vec3    iResolution;
     uniform float   iTime;
     uniform float   iTimeDelta;
@@ -21,7 +21,7 @@ layout(binding = 0) uniform Globals {
 // layout(binding = 2) uniform sampler2D    iChannel2;
 // layout(binding = 3) uniform sampler2D    iChannel3;
 
-layout(location = 0) in vec4 gl_FragCoord;
+/* layout(location = 0) */ in vec4 gl_FragCoord;
 layout(location = 0) out vec4 _fragColor;
 
 #define texture2D texture


### PR DESCRIPTION
This makes us use the stinkier global calls from before OpenGL finally cleaned up the API, but it will allow us to run on more systems.

Fixes #7.