### PR TITLE
fix: Correct buffer scaling when using fractional scale protocol

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -125,7 +125,7 @@
           ];
         } ''
           mkdir -p $out
-          ${pkgs.lib.getExe env.zig} fmt --check .
+          ${pkgs.lib.getExe env.zig} fmt --check ${./.}
         '';
     }));
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -319,8 +319,19 @@ const WlrSurface = struct {
 
         // We want to ignore any exclusive zones set by other surfaces.
         self.wlr_surface.setExclusiveZone(-1);
-        self.wlr_surface.setSize(self.width, self.height);
-        self.wl_surface.setBufferScale(@intCast(self.scale));
+        self.wlr_surface.setSize(self.destination_width, self.destination_height);
+
+        // NOTE: When the wp_fractional_scale_manager_v1 protocol is active, the
+        //       application is responsible for rendering at the exact physical
+        //       pixel size, and the Wayland surface buffer scale should be set
+        //       to 1. We were previously always using the output scale here,
+        //       which caused "source rectangle extends outside of the content
+        //       area" errors on scaled outputs.
+        if (fractional_scale_manager != null) {
+            self.wl_surface.setBufferScale(1);
+        } else {
+            self.wl_surface.setBufferScale(@intCast(self.scale));
+        }
 
         // TODO: Make the user set this.
         self.wlr_surface.setAnchor(.{ .top = true, .left = true });
@@ -420,8 +431,14 @@ const WlrSurface = struct {
         self.destination_width = expected_destination_width;
         self.destination_height = expected_destination_height;
 
-        self.wl_surface.setBufferScale(@intCast(self.scale));
-        self.wlr_surface.setSize(self.width, self.height);
+        // NOTE: See comment in `createEgl` about fractional scale handling.
+        if (self.fractional_scale != null) {
+            self.wl_surface.setBufferScale(1);
+        } else {
+            self.wl_surface.setBufferScale(@intCast(self.scale));
+        }
+
+        self.wlr_surface.setSize(self.destination_width, self.destination_height);
         self.wl_egl_window.resize(@intCast(self.width), @intCast(self.height), 0, 0);
         std.log.debug("Surface resized to ({}, {}) with scale {}", .{ self.width, self.height, self.scale });
 


### PR DESCRIPTION
## Description
This PR fixes an issue where the application would render with incorrect dimensions on Wayland compositors using fractional scaling (in my case Niri).

## The Problem
When the `wp_fractional_scale_manager_v1` protocol is active, the application is responsible for rendering at the exact physical pixel size, and the Wayland surface buffer scale should be set to **1**. 

Previously, the application was correctly using `wp_viewport` for sizing but was *also* setting the `wl_surface` buffer scale to the integer scale factor provided by `wl_output` (e.g., setting it to `2` on a 1.25x scale output). 

This "double scaling" caused the compositor to interpret the buffer as having half the intended logical size (e.g., 3840 physical pixels / scale 2 = 1920 logical pixels), resulting in mismatched window geometry and errors such as:
`wp_viewport: source rectangle extends outside of the content area`

## The Fix
The fix ensures that `wl_surface.setBufferScale` is explicitly set to `1` whenever the `wp_fractional_scale_manager_v1` is available and in use. The existing logic for integer-only scaling remains unchanged to prevent regressions on compositors that do not support fractional scaling.

## Verification
- Tested on **Niri** with a 1.25x scale factor.
- Confirmed that the application now fills the screen correctly without viewport errors.
